### PR TITLE
Rename enum type in parsing.h

### DIFF
--- a/includes/parsing.h
+++ b/includes/parsing.h
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 09:57:48 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/16 10:58:45 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/17 13:53:58 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 /* Differents possible types of each token */
 typedef enum e_type
 {
-	cmd,
+	command,
 	option,
 	redir_in,
 	infile,

--- a/src/parsing/actions_finish.c
+++ b/src/parsing/actions_finish.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 13:59:19 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/16 13:15:56 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/17 13:54:55 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,8 +80,8 @@ void	get_next_type(t_sm *sm, char c)
 		else if (sm->type == redir_out_ap)
 			sm->type = outfile;
 	}
-	else if (sm->type == cmd || sm->type == option)
+	else if (sm->type == command || sm->type == option)
 		sm->type = option;
 	else
-		sm->type = cmd;
+		sm->type = command;
 }

--- a/src/parsing/parsing.c
+++ b/src/parsing/parsing.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/02 11:18:11 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/16 14:01:47 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/17 13:54:55 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,7 @@ t_token	**parsing(char *input)
 }
 
 /* Pour afficher chaque élément séparé avec son type
-printf("0-cmd\n1-option\n2-redir_in\n3-infile\n4-heredoc\n5-limiter\n\
+printf("0-command\n1-option\n2-redir_in\n3-infile\n4-heredoc\n5-limiter\n\
 6-redir_out\n7-redir_out_ap\n8-outfile\n9-t_pipe\n\n");
 if (tokens)
 {

--- a/src/parsing/state_machine.c
+++ b/src/parsing/state_machine.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 11:54:32 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/16 12:51:50 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/17 13:54:55 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,7 @@ t_sm	create_state_machine(char *input)
 	sm = (t_sm){0};
 	sm.input_size = ft_strlen(input);
 	sm.current_state = idle;
-	sm.type = cmd;
+	sm.type = command;
 	return (sm);
 }
 


### PR DESCRIPTION
Renamed enum type 'cmd' to 'command' to avoid conflicts with variables name 'cmd'