### PR TITLE
fixed duplicates and typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,15 @@ CPPFLAGS = -I$(HOME)/.brew/opt/readline/include
 RM = rm -f
 
 SRCS_FILES = 	main.c \
-				tools/signal.c \
-				tools/utils.c \
 				built/builtins.c\
 				built/cd.c\
 				built/echo.c\
 				built/export.c\
 				built/pwd.c\
+				built-ins/cmd_env.c \
+				built-ins/cmd_exit.c \
+				built-ins/cmd_unset.c \
+				errors/print_error.c \
 				exec/child.c \
 				exec/cmd.c \
 				exec/count.c \
@@ -29,6 +31,7 @@ SRCS_FILES = 	main.c \
 				exec/path.c \
 				exec/pipe.c \
 				free/clear_tokens.c \
+				free/clear_minishell.c \
                 parsing_input/actions_finish_buf.c \
 				parsing_input/actions_finish_utils.c \
                 parsing_input/actions_modify.c \
@@ -41,7 +44,7 @@ SRCS_FILES = 	main.c \
                 parsing_input/state_machine.c \
                 parsing_input/state_pipe.c \
                 parsing_input/state_quotes.c \
-				parsing_meta/actions \
+				parsing_meta/actions.c \
 				parsing_meta/parsing_error_meta.c \
 				parsing_meta/parsing_meta.c \
 				parsing_meta/state_chars.c \
@@ -49,6 +52,8 @@ SRCS_FILES = 	main.c \
 				parsing_meta/state_idle.c \
 				parsing_meta/state_machine_meta_utils.c \
 				parsing_meta/state_machine_meta.c \
+				tools/signal.c \
+				tools/utils.c \
 
 SRCS = $(addprefix ./src/, $(SRCS_FILES))
 OBJS = $(SRCS:%.c=%.o)

--- a/src/built-ins/cmd_exit.c
+++ b/src/built-ins/cmd_exit.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/17 11:02:15 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/22 13:47:43 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 09:52:45 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,7 +19,7 @@ least significant byte of status (i.e., status & 0xFF) is returned to the parent
 here it is 
  */
 
-int	cmd_exit(t_data *data, char **cmd_args, int cmd_nbr)
+void	cmd_exit(t_data *data, char **cmd_args, int cmd_nbr)
 {
 	if (cmd_nbr == 1 && ft_strs_len(cmd_args) == 1)
 	{

--- a/src/built-ins/cmd_unset.c
+++ b/src/built-ins/cmd_unset.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/17 11:02:17 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/25 13:50:04 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 09:53:09 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,9 +14,9 @@
 #include <stdbool.h>
 #include <string.h>
 #include <stdio.h>
-#include "print_error.h"
-#include "../../libft/libft.h"
+#include "../../includes/print_error.h"
 #include "../../includes/minishell.h"
+#include "../../libft/libft.h"
 
 int		remove_env_variable(char ***env, int env_size, char *variable);
 int		print_err(char *message, int errnum);

--- a/src/built/builtins.c
+++ b/src/built/builtins.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtins.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lvogt <marvin@42lausanne.ch>               +#+  +:+       +#+        */
+/*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/03 15:01:39 by lvogt             #+#    #+#             */
-/*   Updated: 2023/05/22 11:03:56 by lvogt            ###   ########.fr       */
+/*   Updated: 2023/05/30 10:26:11 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,7 +59,7 @@ void	ft_which_builtins(t_data *data, t_token *token, pid_t *pid)
 	data->exit_code = error;
 }
 
-int	len(t_token *token)
+int	ft_len(t_token *token)
 {
 	t_token	*tmp;
 	int		i;
@@ -83,19 +83,19 @@ int	ft_is_builtins(t_token *token)
 		tmp = tmp->next;
 	if (tmp && tmp->content && tmp->type == command)
 	{
-		if (ft_strcmp_caps((tmp->content), "unset", 5) == 0 && len(tmp) == 5)
+		if (ft_strcmp_caps((tmp->content), "unset", 5) == 0 && ft_len(tmp) == 5)
 			return (1);
-		else if (ft_strcmp_caps((tmp->content), "cd", 2) == 0 && len(tmp) == 2)
+		else if (ft_strcmp_caps((tmp->content), "cd", 2) == 0 && ft_len(tmp) == 2)
 			return (2);
-		else if (ft_strcmp_caps((tmp->content), "exit", 4) == 0 && len(tmp) == 4)
+		else if (ft_strcmp_caps((tmp->content), "exit", 4) == 0 && ft_len(tmp) == 4)
 			return (3);
-		else if (ft_strcmp_caps((tmp->content), "export", 6) == 0 && len(tmp) == 6)
+		else if (ft_strcmp_caps((tmp->content), "export", 6) == 0 && ft_len(tmp) == 6)
 			return (4);
-		if (ft_strcmp_caps((tmp->content), "pwd", 3) == 0 && len(tmp) == 3)
+		if (ft_strcmp_caps((tmp->content), "pwd", 3) == 0 && ft_len(tmp) == 3)
 			return (5);
-		else if (ft_strcmp_caps((tmp->content), "env", 3) == 0 && len(tmp) == 3)
+		else if (ft_strcmp_caps((tmp->content), "env", 3) == 0 && ft_len(tmp) == 3)
 			return (6);
-		else if (ft_strcmp_caps((tmp->content), "echo", 4) == 0 && len(tmp) == 4)
+		else if (ft_strcmp_caps((tmp->content), "echo", 4) == 0 && ft_len(tmp) == 4)
 			return (7);
 	}
 	return (-1);

--- a/src/errors/print_error.c
+++ b/src/errors/print_error.c
@@ -6,11 +6,13 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/23 15:23:09 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/23 15:23:16 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 10:06:48 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include "print_error.h"
+#include <stdio.h>
+#include <string.h>
+#include "../../includes/print_error.h"
 
 int	print_err(char *message, int errnum)
 {

--- a/src/free/clear_minishell.c
+++ b/src/free/clear_minishell.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/17 10:54:19 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/23 14:18:29 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 10:07:08 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,8 +15,6 @@
 
 void	clear_minishell(t_data *data)
 {
-	if (data->tokens)
-		clear_tokens(data->tokens);
 	if (data->envp)
 		ft_strs_free(data->envp, ft_strs_len(data->envp));
 	if (data->cmd)

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/02 10:58:27 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/23 14:18:29 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 10:09:39 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,7 @@ static char	**ft_copy_env(char **env)
 
 static void	ft_good_input(t_data *data)
 {
-	t_token *token;
+	t_token	*token;
 
 	if (ft_strlen(data->user_input) > 0)
 	{

--- a/src/parsing_meta/actions.c
+++ b/src/parsing_meta/actions.c
@@ -6,19 +6,17 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/25 11:16:13 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/26 14:23:02 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 10:24:07 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdlib.h>
-//
 #include <stdio.h>
-//
 #include "../../includes/parsing_meta_state_machine.h"
 #include "../../libft/libft.h"
 
-t_meta	*create_node(char *buffer, t_m_fsm *fsm);
-t_meta	*lst_last(t_meta *meta_strs);
+t_meta	*create_node_meta(char *buffer, t_m_fsm *fsm);
+t_meta	*lst_last_meta(t_meta *meta_strs);
 
 /* Add char to current buffer */
 void	add_to_buf_meta(t_m_fsm *fsm, char c)
@@ -34,21 +32,21 @@ void	finish_buf_meta(t_m_fsm *fsm, t_meta **meta_strs)
 
 	if (fsm->buf_size != 0)
 	{
-		new_meta = create_node(fsm->buf, fsm);
+		new_meta = create_node_meta(fsm->buf, fsm);
 		if (!new_meta)
 			parsing_error_meta(&(fsm->current_state));
 		if (*meta_strs == NULL)
 			*meta_strs = new_meta;
 		else
 		{
-			last = lst_last(*meta_strs);
+			last = lst_last_meta(*meta_strs);
 			last->next = new_meta;
 		}
 		init_meta_state_machine(fsm);
 	}
 }
 
-t_meta	*create_node(char *buffer, t_m_fsm *fsm)
+t_meta	*create_node_meta(char *buffer, t_m_fsm *fsm)
 {
 	t_meta	*meta;
 
@@ -65,7 +63,7 @@ t_meta	*create_node(char *buffer, t_m_fsm *fsm)
 }
 
 /* Get the last element of a chained list */
-t_meta	*lst_last(t_meta *meta_strs)
+t_meta	*lst_last_meta(t_meta *meta_strs)
 {
 	while (meta_strs->next != NULL)
 		meta_strs = meta_strs->next;

--- a/src/parsing_meta/parsing_meta.c
+++ b/src/parsing_meta/parsing_meta.c
@@ -6,11 +6,10 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/23 14:02:29 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/26 15:24:58 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/05/30 10:21:12 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
-#include <stdio.h>
 #include "../../includes/parsing_meta.h"
 #include "../../includes/parsing_meta_state_machine.h"
 #include "../../libft/libft.h"
@@ -55,6 +54,7 @@ void	clear_meta_strs(t_meta *meta_strs)
 		meta_strs = next;
 	}
 }
+
 /*
 #include <stdio.h>
 


### PR DESCRIPTION
- Duplicate function in libft and in src/builtins.c (=> len() changed to ft_len() )
- Duplicate functions in src/parsing_input/actions_finish_buf.c  and src/parsing_meta/actions.c (added "_meta" at the end of function names in actions.c)
- Typo in Makefile, ".c" missing at the end of parsing_meta/actions.c