### PR TITLE
print_err fixed

### DIFF
--- a/src/built-ins/cmd_exit.c
+++ b/src/built-ins/cmd_exit.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/17 11:02:15 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/01 14:46:39 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/02 10:46:16 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -41,7 +41,7 @@ void	get_exit_code(t_data *data)
 	code = ft_itoa(ft_atoi(data->cmd[1]));
 	if (!code)
 	{
-		g_exit_code = print_err("minishell: malloc() failed: %s\n", errno);
+		g_exit_code = print_err("minishell: malloc() failed:", errno);
 		clear_minishell(data);
 	}
 	else if (!ft_strcmp(data->cmd[1], code) && ft_strs_len(data->cmd) == 2)

--- a/src/built-ins/cmd_unset.c
+++ b/src/built-ins/cmd_unset.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/17 11:02:17 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/02 10:04:33 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/02 10:46:16 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,7 @@ int	is_var_present(char ***env, int env_size, char *variable)
 	var = ft_strjoin(variable, "=");
 	if (!var)
 	{
-		g_exit_code = print_err("minishell: malloc() failed: %s\n", errno);
+		g_exit_code = print_err("minishell: malloc() failed:", errno);
 		return (-1);
 	}
 	i = 0;

--- a/src/errors/print_error.c
+++ b/src/errors/print_error.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/23 15:23:09 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/30 10:06:48 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/02 10:44:51 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,7 +18,8 @@ int	print_err(char *message, int errnum)
 {
 	if (errnum != 0)
 	{
-		printf(message, strerror(errnum));
+		printf("%s ", message);
+		printf("%s\n", strerror(errnum));
 		return (errnum);
 	}
 	else

--- a/src/meta_interpret.c
+++ b/src/meta_interpret.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/31 10:32:25 by aaugu             #+#    #+#             */
-/*   Updated: 2023/05/31 13:20:05 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/02 10:46:16 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ void	meta_interpret(t_token *t, char **env, int env_size)
 			buf = parsing_meta(t->content, env, env_size);
 			if (!buf)
 			{
-				print_err("minishell: malloc() failed: %s\n", 0);
+				print_err("minishell: malloc() failed:", errno);
 				return ;
 			}
 			if (!ft_strlen(buf) && (t->type == infile || t->type == outfile))


### PR DESCRIPTION
Print err wasn't printing well malloc errors => "minishell: malloc() failed: %s\n{strerror(errno)}" instead of minishell: malloc() failed: {strerror(errno)}\n"
=> fixed