### PR TITLE
While testing evaluation sheet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = minishell
 CC = gcc
-FLAGS = -Wall -Wextra -Werror
+FLAGS = -Wall -Wextra -Werror -fsanitize=address
 
 INCLUDE = -I includes -I libft
 LIB = -Llibft -lft -lreadline

--- a/includes/parsing_input_state_machine.h
+++ b/includes/parsing_input_state_machine.h
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 11:51:45 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/08 13:02:41 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 12:07:30 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -44,6 +44,7 @@ typedef struct s_fsm
 
 t_token	*state_machine(char *input, char **envp, int env_size);
 void	init_state_machine(t_fsm *fsm);
+void	create_content_empty_token(t_fsm *fsm, t_token **tokens);
 
 /* Each function will set current state and decide to perform an action if
 needed */

--- a/includes/parsing_states.h
+++ b/includes/parsing_states.h
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/26 15:10:52 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/08 11:27:25 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 11:42:46 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ typedef enum e_state
 	dollar,
 	chars,
 	error,
+	malloc_err,
 	stop,
 }			t_state;
 

--- a/src/built-ins/cmd_unset.c
+++ b/src/built-ins/cmd_unset.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/17 11:02:17 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/12 12:56:22 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 11:10:12 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,7 @@
 #include "../../libft/libft.h"
 
 void	remove_var_env(t_data *d);
-int		is_var_present(char ***env, int env_size, char *variable);
+int		is_var_present(t_data *data, char *variable);
 char	**get_new_env(t_data *data, int new_size);
 
 /*
@@ -33,13 +33,13 @@ considered an error and does not cause the shell to abort.
 void	cmd_unset(t_data *data)
 {
 	if (ft_strs_len(data->cmd) <= 1)
-		g_exit_code = print_err("unset: not enough arguments\n", 0);
+		data->exit_code = print_err("unset: not enough arguments\n", 0);
 	else
 		remove_var_env(data);
 }
 
 /* Will try to remove the env variables passed as arguments if found */
-void	remove_var_env(t_data *d)
+void	remove_var_env(t_data *data)
 {
 	int		i;
 	int		res;
@@ -48,25 +48,25 @@ void	remove_var_env(t_data *d)
 
 	i = 0;
 	count = 0;
-	while (++i < ft_strs_len(d->cmd))
+	while (++i < ft_strs_len(data->cmd))
 	{
-		res = is_var_present(&d->envp, d->env_size, (d->cmd)[i]);
+		res = is_var_present(data, (data->cmd)[i]);
 		if (res > 0)
 			count ++;
 		else if (res == -1)
-			clear_minishell(d, g_exit_code);
+			clear_minishell(data, EXIT_FAILURE);
 	}
 	if (count > 0)
 	{
-		new_env = get_new_env(d, d->env_size - count);
-		ft_strs_free(d->envp, d->env_size);
-		d->envp = new_env;
-		d->env_size -= count;
+		new_env = get_new_env(data, data->env_size - count);
+		ft_strs_free(data->envp, data->env_size);
+		data->envp = new_env;
+		data->env_size -= count;
 	}
 }
 
 /* Check if env variable is present in environment and, if found, free it*/
-int	is_var_present(char ***env, int env_size, char *variable)
+int	is_var_present(t_data *data, char *variable)
 {
 	int		i;
 	char	*var;
@@ -74,16 +74,16 @@ int	is_var_present(char ***env, int env_size, char *variable)
 	var = ft_strjoin(variable, "=");
 	if (!var)
 	{
-		g_exit_code = print_err("minishell: malloc() failed:", errno);
+		data->exit_code = print_err("minishell: malloc() failed:", errno);
 		return (-1);
 	}
 	i = 0;
-	while (i < env_size)
+	while (i < data->env_size)
 	{
-		if (ft_strnstr((*env)[i], var, ft_strlen(var)))
+		if (ft_strnstr(data->envp[i], var, ft_strlen(var)))
 		{
-			free((*env)[i]);
-			(*env)[i] = NULL;
+			free(data->envp[i]);
+			data->envp[i] = NULL;
 			free(var);
 			return (true);
 		}

--- a/src/exec/child.c
+++ b/src/exec/child.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   child.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lvogt <marvin@42lausanne.ch>               +#+  +:+       +#+        */
+/*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 11:50:08 by lvogt             #+#    #+#             */
-/*   Updated: 2023/06/12 11:14:47 by lvogt            ###   ########.fr       */
+/*   Updated: 2023/06/13 16:14:34 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
+#include "../../includes/print_error.h"
 
 /* ft_exec_cmd:
  *	Ne fait rien dans les cas des builtin unset et cd ou exit sans option.
@@ -63,7 +64,8 @@ void	ft_free_child(t_token *token, t_data *d)
 	ft_free_double(d->envp);
 	while (token && token->prev)
 		token = token->prev;
-	clear_tokens(&token);
+	if (token)
+		clear_tokens(&token);
 	rl_clear_history();
 	free(d->user_input);
 }
@@ -96,6 +98,11 @@ void	ft_exec_child(t_data *data, t_token *tmp)
 void	ft_process_child(t_data *d, t_token *tmp, pid_t *p)
 {
 	d->cmd = ft_find_cmd(tmp);
+	if (!d->cmd)
+	{
+		d->exit_code = print_err("minishell: malloc() failed:", errno);
+		exit(errno);
+	}
 	ft_builtins_or_cmd(d, tmp, p);
 	p[d->child] = fork();
 	if (p[d->child] < 0)
@@ -110,9 +117,9 @@ void	ft_process_child(t_data *d, t_token *tmp, pid_t *p)
 	if (d->cmd && d->is_builtin < 0)
 		free(d->cmd_path);
 	d->cmd_path = NULL;
-	if (d->cmd)
-	{
-		ft_free_double(d->cmd);
-		d->cmd = NULL;
-	}
+	// if (d->cmd)
+	// {
+	// 	ft_strs_free(d->cmd, ft_strs_len(d->cmd));
+	// 	d->cmd = NULL;
+	// }
 }

--- a/src/exec/child.c
+++ b/src/exec/child.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 11:50:08 by lvogt             #+#    #+#             */
-/*   Updated: 2023/06/13 16:14:34 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/15 09:44:17 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -117,9 +117,9 @@ void	ft_process_child(t_data *d, t_token *tmp, pid_t *p)
 	if (d->cmd && d->is_builtin < 0)
 		free(d->cmd_path);
 	d->cmd_path = NULL;
-	// if (d->cmd)
-	// {
-	// 	ft_strs_free(d->cmd, ft_strs_len(d->cmd));
-	// 	d->cmd = NULL;
-	// }
+	if (d->cmd)
+	{
+		ft_strs_free(d->cmd, ft_strs_len(d->cmd));
+		d->cmd = NULL;
+	}
 }

--- a/src/exec/cmd.c
+++ b/src/exec/cmd.c
@@ -6,11 +6,12 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 12:03:10 by lvogt             #+#    #+#             */
-/*   Updated: 2023/06/13 16:14:49 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/15 09:47:50 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
+#include "../../libft/libft.h"
 
 char	**fill_cmd_with_args(t_token *cmd, int size);
 
@@ -112,7 +113,7 @@ char	**fill_cmd_with_args(t_token *cmd, int size)
 	i = 0;
 	while (i < size)
 	{
-		cmd_args[i] = cmd->content;
+		cmd_args[i] = ft_strdup(cmd->content);
 		if (!cmd_args[i])
 		{
 			ft_strs_free(cmd_args, size);

--- a/src/exec/cmd.c
+++ b/src/exec/cmd.c
@@ -3,14 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   cmd.c                                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lvogt <marvin@42lausanne.ch>               +#+  +:+       +#+        */
+/*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 12:03:10 by lvogt             #+#    #+#             */
-/*   Updated: 2023/06/07 12:10:56 by lvogt            ###   ########.fr       */
+/*   Updated: 2023/06/13 16:14:49 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../includes/minishell.h"
+
+char	**fill_cmd_with_args(t_token *cmd, int size);
 
 /* find_cmd_path:
  *	Regarde si la commande commence par "./"
@@ -69,30 +71,6 @@ void	ft_builtins_or_cmd(t_data *d, t_token *tmp, pid_t *pid)
 	}
 }
 
-/* ft_full_str:
- *	Join la commande avec ses options séparé par un espace. 
- */
-char	*ft_full_str(t_token *token)
-{
-	t_token	*tmp;
-	char	*str;
-	char	*tmp2;
-
-	tmp = token;
-	str = ft_strdup(tmp->content);
-	while (tmp->next && tmp->next->type == option)
-	{
-		tmp = tmp->next;
-		tmp2 = ft_strjoin(str, " ");
-		free(str);
-		str = ft_strjoin(tmp2, tmp->content);
-		free(tmp2);
-	}
-	if (str)
-		return (str);
-	return (NULL);
-}
-
 /* ft_find_cmd:
  *	Recherche une commande et ses options pour les returnes
  *	sous la forme d'un tableau de char.
@@ -100,23 +78,50 @@ char	*ft_full_str(t_token *token)
 char	**ft_find_cmd(t_token *token)
 {
 	t_token	*tmp;
-	char	**cmd;
-	char	*str;
+	t_token	*cmd;
+	char	**cmd_args;
+	int		size;
 
+	cmd_args = NULL;
 	tmp = token;
-	if (tmp && tmp->type == t_pipe)
+	if (tmp && tmp->type != command)
 		tmp = tmp->next;
-	while (tmp && tmp->type != t_pipe && tmp->type != command)
-		tmp = tmp->next;
-	if (tmp && tmp->type == command)
+	cmd = tmp;
+	tmp = tmp->next;
+	size = 1;
+	while (tmp && tmp->type == option)
 	{
-		str = ft_full_str(tmp);
-		cmd = ft_split(str, ' ');
-		free(str);
-		if (cmd)
-			return (cmd);
+		size++;
+		tmp = tmp->next;
 	}
-	return (NULL);
+	cmd_args = fill_cmd_with_args(cmd, size);
+	if (!cmd_args)
+		return (NULL);
+	return (cmd_args);
+}
+
+char	**fill_cmd_with_args(t_token *cmd, int size)
+{
+	char	**cmd_args;
+	int		i;
+
+	cmd_args = (char **)malloc(sizeof(char *) * (size + 1));
+	if (!cmd_args)
+		return (NULL);
+	cmd_args[size] = NULL;
+	i = 0;
+	while (i < size)
+	{
+		cmd_args[i] = cmd->content;
+		if (!cmd_args[i])
+		{
+			ft_strs_free(cmd_args, size);
+			return (NULL);
+		}
+		i++;
+		cmd = cmd->next;
+	}
+	return (cmd_args);
 }
 
 /* ft_is_cmd:

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lvogt <marvin@42lausanne.ch>               +#+  +:+       +#+        */
+/*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/03 11:15:04 by lvogt             #+#    #+#             */
-/*   Updated: 2023/06/12 15:54:29 by lvogt            ###   ########.fr       */
+/*   Updated: 2023/06/13 11:11:59 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -61,7 +61,6 @@ void	ft_wait(pid_t *pid, t_data *data)
 		wpid = waitpid(pid[i], &status, 0);
 		if (WIFSIGNALED(status))
 			data->exit_code = 130;
-		printf("\n\n%d\n\n", data->exit_code);
 		if (WIFEXITED(status))
 			data->exit_code = WEXITSTATUS(status);
 		i++;

--- a/src/main.c
+++ b/src/main.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   main.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: lvogt <marvin@42lausanne.ch>               +#+  +:+       +#+        */
+/*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/02 10:58:27 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/12 16:00:17 by lvogt            ###   ########.fr       */
+/*   Updated: 2023/06/13 14:16:55 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,24 +40,24 @@ static char	**ft_copy_env(char **env)
 
 static void	ft_good_input(t_data *data)
 {
-	t_token	*token;
+	t_token	*tokens;
 
-	token = NULL;
+	tokens = NULL;
 	if (ft_strlen(data->user_input) > 0)
 	{
 		add_history(data->user_input);
-		token = parsing_input(data->user_input, data->envp, data->env_size);
-		if (!token)
+		tokens = parsing_input(data->user_input, data->envp, data->env_size);
+		if (!tokens)
 			clear_minishell(data, g_exit_code);
-		if (ft_strlen(token->content) != 0)
+		if (ft_strlen(tokens->content) != 0)
 		{	
-			meta_interpret(data, token);
-			ft_executor(token, data);
+			meta_interpret(data, tokens);
+			ft_executor(tokens, data);
 		}
 		if (data->user_input)
 			free(data->user_input);
-		if (token)
-			clear_tokens(&token);
+		if (tokens)
+			clear_tokens(&tokens);
 	}
 }
 

--- a/src/parsing/parsing-input/actions_finish_buf.c
+++ b/src/parsing/parsing-input/actions_finish_buf.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 13:59:19 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/12 15:03:00 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 13:58:23 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,6 @@ void	finish_buf(t_fsm *fsm, t_token **tokens, char c)
 
 	if (fsm->buf_size != 0 || c == '\0')
 	{
-		fsm->buf[fsm->buf_size] = '\0';
 		new_token = create_node(fsm);
 		if (!new_token)
 			parsing_error(fsm, 0);

--- a/src/parsing/parsing-input/parsing_error.c
+++ b/src/parsing/parsing-input/parsing_error.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/08 09:55:57 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/02 15:39:22 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 12:06:54 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,11 +26,12 @@ void	parsing_error(t_fsm *fsm, char *s)
 		else
 			printf("minishell: syntax error near unexpected token `%c'\n", s[0]);
 		g_exit_code = 258;
+		fsm->current_state = error;
 	}
 	else
 	{
 		printf("minishell: malloc() failed: %s\n", strerror(errno));
 		g_exit_code = errno;
+		fsm->current_state = malloc_err;
 	}
-	fsm->current_state = error;
 }

--- a/src/parsing/parsing-input/parsing_input.c
+++ b/src/parsing/parsing-input/parsing_input.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/02 11:18:11 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/12 14:58:23 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 14:13:34 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,8 +22,6 @@ t_token	*parsing_input(char *input, char **env, int env_size)
 	t_token	*tokens;
 
 	tokens = state_machine(input, env, env_size);
-	if (!tokens)
-		return (NULL);
 	return (tokens);
 }
 
@@ -32,10 +30,10 @@ t_token	*parsing_input(char *input, char **env, int env_size)
 	6-redir_out\n7-redir_out_ap\n8-outfile\n9-t_pipe\n\n");
 	if (tokens)
 	{
-		while ((*tokens))
+		while (tokens)
 		{
-			printf("%d : %s\n", (*tokens)->type, (*tokens)->content);
-			(*tokens) = (*tokens)->next;
+			printf("%d : %s\n", tokens->type, tokens->content);
+			tokens = tokens->next;
 		}
 	}
 */

--- a/src/parsing/parsing-input/state_machine.c
+++ b/src/parsing/parsing-input/state_machine.c
@@ -6,7 +6,7 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/05 11:54:32 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/12 15:16:12 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 13:46:50 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,6 @@
 void	create_state_machine(t_fsm *fsm, char **env, int env_size, char *input);
 void	execute_state_machine(t_fsm *fsm, t_token **tokens, char c);
 void	clear_state_machine(t_fsm *fsm);
-void	clear_parsing_error(t_fsm *fsm, t_token **tokens);
 
 /* Finite state machine. Will loop on each char to know how to separate each
 token in a lineary way. */
@@ -36,19 +35,21 @@ t_token	*state_machine(char *input, char **envp, int env_size)
 	i = 0;
 	while (i <= (int)ft_strlen(input))
 	{
-		if (fsm.current_state == error)
-		{
-			clear_parsing_error(&fsm, &tokens);
-			return (NULL);
-		}
+		if (fsm.current_state == error || fsm.current_state == malloc_err)
+			break ;
 		else
 			execute_state_machine(&fsm, &tokens, input[i]);
 		i++;
 	}
+	if (fsm.current_state == error)
+		create_content_empty_token(&fsm, &tokens);
+	else if (fsm.current_state == malloc_err)
+	{
+		clear_tokens(&tokens);
+		tokens = NULL;
+	}
 	clear_state_machine(&fsm);
-	if (fsm.current_state == stop)
-		return (tokens);
-	return (NULL);
+	return (tokens);
 }
 
 /* Tells state machine what to do depending on current state. Method flexible,
@@ -101,10 +102,10 @@ void	clear_state_machine(t_fsm *fsm)
 	fsm = (t_fsm *){0};
 }
 
-/* If an error is encountered, clear allocated memory of finite state machine
-and tokens */
-void	clear_parsing_error(t_fsm *fsm, t_token **tokens)
-{
-	clear_state_machine(fsm);
-	clear_tokens(tokens);
-}
+// /* If an error is encountered, clear allocated memory of finite state machine
+// and tokens */
+// void	clear_parsing_error(t_fsm *fsm, t_token **tokens)
+// {
+// 	clear_state_machine(fsm);
+// 	clear_tokens(tokens);
+// }

--- a/src/parsing/parsing-input/state_machine_utils.c
+++ b/src/parsing/parsing-input/state_machine_utils.c
@@ -6,11 +6,12 @@
 /*   By: aaugu <aaugu@student.42lausanne.ch>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/05/16 11:22:46 by aaugu             #+#    #+#             */
-/*   Updated: 2023/06/02 15:39:47 by aaugu            ###   ########.fr       */
+/*   Updated: 2023/06/13 13:26:25 by aaugu            ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdbool.h>
+#include <stdio.h>
 #include "../../../includes/parsing_input_state_machine.h"
 #include "../../../libft/libft.h"
 
@@ -24,4 +25,13 @@ void	init_state_machine(t_fsm *fsm)
 		parsing_error(fsm, 0);
 	fsm->buf_size = 0;
 	fsm->meta = true;
+}
+
+void	create_content_empty_token(t_fsm *fsm, t_token **tokens)
+{
+	if (tokens)
+		clear_tokens(tokens);
+	*tokens = NULL;
+	init_state_machine(fsm);
+	finish_buf(fsm, tokens, '\0');
 }


### PR DESCRIPTION
- Separate error state into malloc_err and error states, otherwise return Null even if token content just empty
- While joining command and arguments, whitespaces were removed. Fixed in ft_find_cmd()
- Forgot to Change modification of exit code in cmd_unset()